### PR TITLE
Handle client https errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,12 @@ var Init = {
           if (r.statusCode == 404) {
             return reject(new Error("Example '" + name + "' doesn't exist. If you believe this is an error, please contact Truffle support."));
           } else if (r.statusCode != 200) {
-            return reject(new Error("Error connecting to github.com. Please check your internet connection and try again."));
+            return reject(new Error("Error connecting to github.com. Please try again later."));
           }
           accept();
+        });
+        req.on('error', function(err) {
+          return reject(new Error("Error connecting to github.com. Please check your internet connection and try again."));
         });
         req.end();
 


### PR DESCRIPTION
Node's [`https.request`](https://nodejs.org/api/https.html#https_https_request_options_callback) doesn't execute its callback when there is a client error. If this happened an exception was thrown that crashes the cli process.

Steps to reproduce it:
1.  Go offline
2. `truffle init webpack`
3. The process is terminated with this message: 
```events.js:163
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo ENOTFOUND raw.githubusercontent.com raw.githubusercontent.com:443
    at errnoException (dns.js:28:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:73:26)
```

There was some attemp to handle this case, but due to `https.request`'s odd API it didn't work as expected. This PR fixes it.