### PR TITLE
Switching to request library that supports the proxy environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var temp = require("temp");
 var ghdownload = require('github-download');
 var path = require("path");
 var fs = require("fs-extra");
-var https = require("https");
 var npm = require('npm-programmatic');
+var request = require('request');
 
 var Init = {
 
@@ -32,10 +32,9 @@ var Init = {
 
         var options = {
           method: 'HEAD',
-          host: 'raw.githubusercontent.com',
-          path: '/trufflesuite/' + expected_full_name + "/master/truffle.js"
+          uri: 'https://raw.githubusercontent.com/trufflesuite/' + expected_full_name + "/master/truffle.js"
         };
-        req = https.request(options, function(r) {
+      	request(options, function(error, r, body) {
           if (r.statusCode == 404) {
             return reject(new Error("Example '" + name + "' doesn't exist. If you believe this is an error, please contact Truffle support."));
           } else if (r.statusCode != 200) {
@@ -43,8 +42,6 @@ var Init = {
           }
           accept();
         });
-        req.end();
-
       });
     }).then(function() {
       // Remove the temp directory, if it exists, just to remove the

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fs-extra": "^2.0.0",
     "github-download": "^0.5.0",
     "npm-programmatic": "0.0.6",
+    "request": "^2.83.0",
     "rimraf": "^2.5.4",
     "temp": "^0.8.3",
     "truffle-config": "^1.0.1"


### PR DESCRIPTION
The native nodejs https.request method doesn't follow proxy environment variables.
This is referenced by https://github.com/nodejs/node/issues/8381

The request library does support these environment variables.

These environment variables are commonly used at the corporation I work for, so not supporting them is a barrier to entry for many corporate developers.

